### PR TITLE
doc: addressing draft implementation audit

### DIFF
--- a/docs/x402_implementation_plan.md
+++ b/docs/x402_implementation_plan.md
@@ -70,21 +70,32 @@ if paymentData is empty:
     return super._adjustInitialBalance(requester, balance, deliveryRate, "")
     // Falls back to standard transferFrom behavior
 
-// Decode EIP-3009 params from paymentData
-(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore,
- bytes32 nonce, uint8 v, bytes32 r, bytes32 s) = abi.decode(paymentData, ...)
+// Decode array of EIP-3009 authorizations from paymentData
+// Single auth is encoded as a one-element array; batches use N-element arrays
+Authorization[] memory auths = abi.decode(paymentData, (Authorization[]))
 
-// Validations
-require(from == requester)          // X402InvalidSender
-require(to == address(this))        // X402InvalidRecipient
-require(value + balance >= deliveryRate)  // X402InsufficientPayment
+uint256 totalTransferred;
+for (uint256 i = 0; i < auths.length; i++):
+    // Validations per authorization
+    require(auths[i].from == requester)      // X402InvalidSender
+    require(auths[i].to == address(this))    // X402InvalidRecipient
 
-// Execute atomic transfer — bypasses _getRequiredFunds/transferFrom entirely
-IUSDC(token).transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, v, r, s)
+    // Execute atomic transfer — bypasses _getRequiredFunds/transferFrom entirely
+    IUSDC(token).transferWithAuthorization(
+        auths[i].from, auths[i].to, auths[i].value,
+        auths[i].validAfter, auths[i].validBefore,
+        auths[i].nonce, auths[i].v, auths[i].r, auths[i].s
+    )
+    totalTransferred += auths[i].value
+
+// Check total covers delivery rate (which is already the summed total for batches)
+require(balance + totalTransferred >= deliveryRate)  // X402InsufficientPayment
 
 // Update balance: add received funds, subtract delivery rate
-return (balance + value - deliveryRate)
+return (balance + totalTransferred - deliveryRate)
 ```
+
+This design supports both per-request settlement (single-element array) and batching (N-element array) with zero interface changes to MechMarketplace or OlasMech.
 
 **Constructor:** Same as `BalanceTrackerFixedPriceToken` — `(mechMarketplace, drainer, usdcTokenAddress)`
 
@@ -110,9 +121,26 @@ bytes32 public constant PAYMENT_TYPE = 0x...;
 
 **Pattern:** Identical to `MechFactoryFixedPriceTokenUSDC` but creates `MechFixedPriceTokenX402` instances.
 
-#### 1.4 Add error definitions
+#### 1.4 Add struct and error definitions
 
-In `contracts/interfaces/IErrorsMarketplace.sol` or a new `IErrorsX402.sol`:
+In `contracts/mechs/token/x402/BalanceTrackerX402.sol` (or a shared interface):
+
+**Struct:**
+```solidity
+struct Authorization {
+    address from;
+    address to;
+    uint256 value;
+    uint256 validAfter;
+    uint256 validBefore;
+    bytes32 nonce;
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+}
+```
+
+**Custom errors** (in `IErrorsX402.sol` or inline):
 - `X402InvalidSender(address provided, address expected)`
 - `X402InvalidRecipient(address provided, address expected)`
 - `X402InsufficientPayment(uint256 provided, uint256 required)`
@@ -127,7 +155,8 @@ In `contracts/interfaces/IErrorsMarketplace.sol` or a new `IErrorsX402.sol`:
 1. **Happy path:** Client signs EIP-3009, mech delivers via `deliverMarketplaceWithSignatures` with `paymentData`, `_adjustInitialBalance` override executes `transferWithAuthorization`, funds move atomically, balances update correctly
 2. **Fallback:** Empty `paymentData` falls back to standard `transferFrom` pre-deposit flow via `super._adjustInitialBalance`
 3. **Validation failures:** Wrong `from` address, wrong `to` address, insufficient `value`, expired `validBefore`, already-used nonce
-4. **Per-request settlement:** Single-element arrays with individual EIP-3009 authorizations
+4. **Per-request settlement:** Single-element authorization arrays with individual EIP-3009 authorizations
+4b. **Batch settlement:** Multi-element authorization arrays — multiple `transferWithAuthorization` calls in one tx, total covers summed delivery rates
 5. **Fee accounting:** Verify `processPaymentByMultisig` fee calculation is unchanged
 6. **Reentrancy:** Attempt reentrancy via malicious token (reuse existing `MechReentrancyAttacker` pattern)
 
@@ -228,7 +257,7 @@ Most gaps identified in the earlier review have been addressed by the updated sp
 
 ### ~~Open Item 1 — Batch Loop Claim~~ (Resolved)
 
-Spec Section 3.3 has been corrected. It now accurately describes that `_adjustInitialBalance` is called once with the summed total, and that per-request settlement is the only practical approach for x402.
+Spec Section 3.3 has been corrected. It now accurately describes that `_adjustInitialBalance` is called once with the summed total. Batching IS supported by encoding multiple EIP-3009 authorizations as an array in `paymentData` — the `BalanceTrackerX402` override loops through each auth and calls `transferWithAuthorization` per auth. Per-request settlement is recommended for v1 simplicity, with batching as a later optimization.
 
 ### Open Item 2 — Gnosis USDC EIP-3009 Verification
 

--- a/docs/x402_key_findings_pre_audit.md
+++ b/docs/x402_key_findings_pre_audit.md
@@ -9,14 +9,15 @@
 | # | Severity | Finding | Component |
 |---|----------|---------|-----------|
 | H-1 | High | Settlement race condition — client can drain USDC between tool execution and on-chain settlement | BalanceTrackerX402 |
-| H-2 | High | EIP-3009 cross-chain replay risk (theoretical — mitigated by different USDC addresses per chain) | BalanceTrackerX402 |
-| M-1 | Medium | `paymentData` ABI decode safety — malformed data can revert entire batch | BalanceTrackerX402 |
-| M-2 | Medium | Nonce persistence — in-memory nonce set lost on mech crash, risk of tool re-execution | Off-chain (mech app) |
-| M-3 | Medium | **BLOCKER**: Gnosis bridged USDC EIP-3009 support unverified on-chain | Deployment |
-| L-1 | Low | Fee rounding to zero when `maxDeliveryRate` is very small | Dynamic pricing |
-| L-2 | Low | Circuit breaker scope (per-chain vs global) and reset mechanism undefined | Off-chain (mech app) |
+| M-1 | Medium | Nonce persistence — in-memory nonce set lost on mech crash, risk of tool re-execution | Off-chain (mech app) |
+| M-2 | Medium | **BLOCKER**: Gnosis bridged USDC EIP-3009 support unverified on-chain | Deployment |
+| L-1 | Low | Circuit breaker scope (per-chain vs global) and reset mechanism undefined | Off-chain (mech app) |
 | N-1 | Note | Request signature transport mechanism undecided (Issue C in spec) | Protocol design |
 | N-2 | Note | Fork-based integration tests required alongside mock unit tests | Testing |
+| N-3 | Note | Multi-mech isolation mechanism mis-identified in spec (shared BalanceTracker, not per-mech) | Spec correction |
+| ~~H-2~~ | ~~High~~ | ~~EIP-3009 cross-chain replay~~ — Removed: USDC's own EIP-712 domain separator handles this | N/A |
+| ~~old M-1~~ | ~~Medium~~ | ~~paymentData ABI decode safety~~ — Removed: `abi.decode` revert is correct; try/catch would allow unpaid deliveries | N/A |
+| ~~old L-1~~ | ~~Low~~ | ~~Fee rounding to zero~~ — Removed: ceil division already prevents this | N/A |
 
 ## H-1: Settlement Race Condition
 
@@ -26,35 +27,36 @@ The x402 flow separates tool execution (immediate, off-chain) from payment settl
 
 **Concern**: The architecture allows arbitrary `maxDeliveryRate`. If a mech charges $100/request, the unsecured window becomes meaningful.
 
+**Mitigating factor**: The requester explicitly signs the delivery rate as part of the requestId (`getRequestId` includes `deliveryRate` at MechMarketplace line 232), and `_verifySignedHash` validates this signature (line 236). The mech cannot inflate the rate beyond what the requester agreed to.
+
 **Recommendations**:
 - Document maximum acceptable `maxDeliveryRate` for x402 flow
 - Enforce off-chain balance check at verification time (Step 6)
 - Circuit breaker (503 after 3 consecutive failures) is a good existing mitigation
 
-## H-2: EIP-3009 Cross-Chain Replay
+## ~~H-2: EIP-3009 Cross-Chain Replay~~ — REMOVED
 
-EIP-3009 `transferWithAuthorization` uses EIP-712 domain separator which includes `chainId`. The spec deploys `BalanceTrackerX402` on multiple chains (Base, Optimism, Polygon, Gnosis). Cross-chain replay is prevented at the USDC contract level because Circle deploys USDC at different addresses per chain.
+**Original claim**: `BalanceTrackerX402` should store `block.chainid` to prevent cross-chain replay.
 
-**Residual risk**: If the same USDC address were to exist on two chains (e.g., via CREATE2), replay would be possible.
+**Why removed**: `BalanceTrackerX402` does not verify EIP-3009 signatures — USDC does. USDC's own EIP-712 domain separator already includes both `chainId` and `verifyingContract` (the USDC contract address, which differs per chain). Adding chainId validation to the BalanceTracker would be redundant gas cost with zero security benefit. The theoretical "same USDC address on two chains via CREATE2" scenario is not realistic — Circle deploys USDC via proxies with chain-specific governance.
 
-**Recommendation**: `BalanceTrackerX402` constructor should validate `block.chainid` matches expected chain and store it as immutable.
+## ~~M-1: paymentData ABI Decode Safety~~ — REMOVED
 
-## M-1: paymentData ABI Decode Safety
+**Original recommendations**: Validate `paymentData.length`, use try/catch around `transferWithAuthorization`, emit failure events.
 
-`BalanceTrackerX402._adjustInitialBalance()` will `abi.decode(paymentData, ...)` to extract EIP-3009 parameters. Malformed `paymentData` could cause a revert. Although the spec mandates per-request settlement (isolating failures), the decode must be robust.
+**Why removed**:
+- **try/catch is harmful**: If `transferWithAuthorization` fails but the delivery is recorded (not reverted), the mech gets credited without funds arriving. The atomic revert is the correct behavior — it prevents unpaid deliveries.
+- **Length validation is redundant**: `abi.decode` already reverts on malformed input. An explicit length check adds gas for no benefit.
+- **Emit + revert is impossible**: Cannot emit an event and revert in the same transaction (the event is rolled back).
+- **Per-request settlement already isolates failures**: The spec recommends single-element arrays, so one bad `paymentData` cannot affect unrelated deliveries.
 
-**Recommendations**:
-- Validate `paymentData.length` before decoding
-- Use try/catch around `transferWithAuthorization` call
-- Emit failure event with reason for debugging
-
-## M-2: Nonce Management Consistency
+## M-1: Nonce Management Consistency
 
 EIP-3009 uses random 32-byte nonces. The mech maintains a local nonce set for off-chain dedup, persisted to `synchronized_data`. If the mech crashes between verification and settlement, the nonce set may be lost. USDC's on-chain nonce tracking prevents double-payment, but the mech may re-execute the tool (computational cost, not financial loss).
 
 **Recommendation**: Persist nonces to disk/DB, not just in-memory. The spec's `synchronized_data` approach is correct but must survive restarts.
 
-## M-3: Gnosis Bridged USDC — BLOCKER
+## M-2: Gnosis Bridged USDC — BLOCKER
 
 Gnosis USDC (`0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0`) is bridged, not native Circle USDC. Bridged USDC implementations often lack `transferWithAuthorization`. Calling it on a contract that doesn't implement it will revert, freezing all x402 settlements on that chain.
 
@@ -63,9 +65,36 @@ Gnosis USDC (`0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0`) is bridged, not nativ
 - If not supported, exclude Gnosis from v1 targets
 - Base and Optimism (native Circle USDC) are confirmed safe targets
 
+## ~~L-1: Fee Rounding to Zero~~ — REMOVED
+
+**Original claim**: Fee can round to zero when `maxDeliveryRate` is very small.
+
+**Why removed**: `_processPayment` in BalanceTrackerBase (line 158) uses **ceil division**:
+```solidity
+marketplaceFee = (balance * fee + (MAX_FEE_FACTOR - 1)) / MAX_FEE_FACTOR;
+```
+When `fee > 0` and `balance >= 1`, `marketplaceFee` is always `>= 1`. Additionally, fees are calculated on accumulated `mapMechBalances[mech]` (after multiple deliveries), not per-request — so small individual delivery rates aggregate before the fee is taken.
+
+## N-3: Multi-Mech Isolation Mechanism Mis-Identified in Spec
+
+Spec Section 3.7 states: "Each mech has its own `BalanceTrackerX402` address (the `to` field in the EIP-3009 authorization)."
+
+**This is incorrect.** There is ONE `BalanceTrackerX402` per payment type, shared by ALL x402 mechs (`mapPaymentTypeBalanceTrackers[paymentType]` at MechMarketplace line 811). The `to` field in every x402 EIP-3009 authorization is the SAME address.
+
+Cross-mech replay is still prevented, but by different mechanisms:
+1. **USDC nonce consumption**: Each `transferWithAuthorization` nonce is one-time use at the USDC contract level. Once consumed, it cannot be replayed by any mech.
+2. **Request signature binding**: The `requestId` includes the mech address (`getRequestId` at line 232: `abi.encode(address(this), mech, requester, ...)`). The requester's signature is verified against this requestId. A different mech cannot forge a valid requestId for the same request.
+
+**Recommendation**: Fix Section 3.7 to describe the actual isolation mechanism.
+
 ## Overall Assessment
 
-The x402 integration design is architecturally sound and security-conscious. The key risk is the settlement window between tool execution and on-chain payment (H-1), which the spec explicitly accepts for small amounts. The biggest blocker is Gnosis USDC EIP-3009 verification (M-3).
+The x402 integration design is architecturally sound and security-conscious. The key risk is the settlement window between tool execution and on-chain payment (H-1), which the spec explicitly accepts for small amounts. The biggest blocker is Gnosis USDC EIP-3009 verification (M-2).
+
+Three original findings were removed after code review:
+- **H-2** (cross-chain replay): USDC's own domain separator handles this; BalanceTracker doesn't verify signatures.
+- **M-1** (ABI decode safety): Atomic revert on bad `paymentData` is correct behavior; try/catch would allow unpaid deliveries.
+- **L-1** (fee rounding): Ceil division already prevents rounding to zero.
 
 **Critical function to audit post-implementation**: `BalanceTrackerX402._adjustInitialBalance()` — the only new on-chain logic touching user funds.
 

--- a/docs/x402_spec.md
+++ b/docs/x402_spec.md
@@ -134,7 +134,13 @@ The mech queries `MechMarketplace.fee()` for fee bps and returns this quote in t
 
 #### Batch semantics
 
-In `adjustMechRequesterBalances` (BalanceTrackerBase.sol), the batch loop sums `mechDeliveryRates[]` into `totalMechDeliveryRate`, then `_adjustInitialBalance` is called **once** with that total — not once per request. This means a single `paymentData` (single EIP-3009 authorization) must cover the summed total of all delivery rates in the batch. Batching is therefore impractical for x402: each HTTP request arrives independently with its own `X-Payment` header and EIP-3009 signature, and the client cannot know the aggregate amount at signing time. **Per-request settlement (single-element arrays) is the only practical approach.**
+In `adjustMechRequesterBalances` (BalanceTrackerBase.sol), the batch loop sums `mechDeliveryRates[]` into `totalMechDeliveryRate`, then `_adjustInitialBalance` is called **once** with that total — not once per request.
+
+**Batching IS achievable.** Because `paymentData` is an opaque `bytes` blob interpreted only by the specific BalanceTracker, `BalanceTrackerX402._adjustInitialBalance` can decode it as an **array** of EIP-3009 authorizations. The override loops through each authorization, calls `transferWithAuthorization` for each, sums the transferred amounts, and checks the total covers `totalMechDeliveryRate`. No changes to `MechMarketplace`, `OlasMech`, or the `paymentData` interface are required.
+
+Off-chain, the mech accumulates multiple x402 requests (each with its own EIP-3009 auth from the HTTP `X-Payment` header), encodes all authorizations into a single `paymentData = abi.encode(authArray)`, and calls `deliverMarketplaceWithSignatures` as a normal batch. Each `transferWithAuthorization` is still ~50k gas, but the marketplace overhead (signature verification, karma updates, request bookkeeping) is amortized — one transaction instead of N.
+
+**Per-request settlement is recommended for v1.** While batching is supported at the SC level, per-request settlement (single-element arrays) is simpler to implement off-chain and isolates failures. Batching can be enabled as an optimization in a later iteration.
 
 **Critical: atomic batch revert.** Unlike `deliverMarketplace` (which uses `continue` to skip failed deliveries and returns a `bool[]`), `deliverMarketplaceWithSignatures` reverts the **entire transaction** if any single delivery fails — there is no partial success. Failure causes include bad signatures (`SignatureNotValidated`), duplicate request IDs (`AlreadyRequested`), and insufficient funds (`InsufficientBalance`). Per-request settlement (single-element arrays) is recommended to isolate failures and avoid one bad payment killing unrelated deliveries. The mech should pre-validate each EIP-3009 signature off-chain before submission to minimize on-chain reverts.
 
@@ -226,7 +232,11 @@ EIP-3009 nonces are random `bytes32` values (not sequential), generated per-requ
 4. If the nonce is fresh, it is added to the set and the request proceeds.
 5. The nonce set is persisted to the mech's shared state (`synchronized_data`) so it survives agent restarts and is consistent across the agent ensemble.
 
-**Multi-mech isolation:** Each mech has its own `BalanceTrackerX402` address (the `to` field in the EIP-3009 authorization). An authorization signed for one mech's balance tracker cannot be replayed against a different mech. Cross-mech nonce tracking is not required.
+**Multi-mech isolation:** All x402 mechs share a single `BalanceTrackerX402` contract (resolved via `mapPaymentTypeBalanceTrackers[paymentType]`). The `to` field in every EIP-3009 authorization is the same address. Cross-mech replay is prevented by two independent mechanisms:
+1. **USDC nonce consumption:** Each `transferWithAuthorization` nonce is one-time use at the USDC contract level. Once consumed, it cannot be replayed by any party.
+2. **Request signature binding:** The `requestId` includes the mech address (via `getRequestId(mech, requester, data, deliveryRate, paymentType, nonce)`), and the requester's signature is verified against this requestId. A different mech cannot produce a valid requestId for the same signed request.
+
+Cross-mech nonce tracking is not required.
 
 ---
 
@@ -469,7 +479,7 @@ Unit tests for the three new contracts, covering:
 1. **Happy path:** Client signs EIP-3009, mech delivers via `deliverMarketplaceWithSignatures` with `paymentData`, `_adjustInitialBalance` override executes `transferWithAuthorization`, funds move atomically, balances update correctly
 2. **Fallback:** Empty `paymentData` falls back to standard `transferFrom` pre-deposit flow via `super._adjustInitialBalance`
 3. **Validation failures:** Wrong `from` address, wrong `to` address, insufficient `value`, expired `validBefore`, already-used nonce
-4. **Batch delivery:** Multiple requests in one call, each with its own EIP-3009 authorization and unique nonce
+4. **Batch delivery:** Multiple requests in one call with array-encoded `paymentData` containing multiple EIP-3009 authorizations (each with unique nonce), verifying total transferred covers summed delivery rates
 5. **Fee accounting:** Verify `processPaymentByMultisig` fee calculation is unchanged
 6. **Reentrancy:** Attempt reentrancy via malicious token (reuse existing `MechReentrancyAttacker` pattern)
 


### PR DESCRIPTION
  Correct x402 pre-audit findings and align specs after code review:

  - Remove H-2 (cross-chain replay): USDC's own EIP-712 domain separator
    handles this; BalanceTracker doesn't verify signatures
  - Remove old M-1 (ABI decode safety): try/catch would allow unpaid
    deliveries; atomic revert is correct behavior
  - Remove old L-1 (fee rounding): ceil division already prevents
    rounding to zero
  - Strengthen H-1: add mitigating factor (requester signs deliveryRate
    in requestId, mech cannot inflate)
  - Add N-3: multi-mech isolation in spec incorrectly claimed per-mech
    BalanceTracker addresses; actually one shared tracker with isolation
    via USDC nonce consumption + request signature binding
  - Fix spec Section 3.3: batching IS achievable by array-encoding
    multiple EIP-3009 auths in opaque paymentData blob; no SC interface
    changes needed
  - Fix spec Section 3.7: correct multi-mech isolation mechanism
  - Update implementation plan: Authorization[] struct, array-decoded
    _adjustInitialBalance pseudocode, batch test case