### PR TITLE
docs: vulnerability #16 (NVM native depositFor) + v0.4.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org).
 
+[0.4.2]: https://github.com/valory-xyz/autonolas-marketplace/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/valory-xyz/autonolas-marketplace/compare/v0.3.1...v0.4.1
 [0.3.1]: https://github.com/valory-xyz/autonolas-marketplace/compare/v0.2.1...v0.3.1
 [0.2.1]: https://github.com/valory-xyz/autonolas-marketplace/compare/v0.1.0...v0.2.1
 [0.1.0]: https://github.com/valory-xyz/autonolas-marketplace/releases/tag/v0.1.0
 
+
+## [0.4.2] - 2026-05-25
+
+- New USDC fixed-price contracts: `MechFactoryFixedPriceTokenUSDC` and `MechFixedPriceTokenUSDC` ([#140](https://github.com/valory-xyz/autonolas-marketplace/pull/140))
+- New Celo-specific `BalanceTrackerFixedPriceNativeCelo` variant (CELO native is itself an ERC-20, so `_wrap()` is overridden to a no-op) ([#147](https://github.com/valory-xyz/autonolas-marketplace/pull/147))
+- `BalanceTrackerNvmSubscriptionNative`: override `depositFor()` to revert with `NoDepositAllowed`, preventing direct native deposits that bypass the subscription model ([#129](https://github.com/valory-xyz/autonolas-marketplace/pull/129))
+- Multi-chain deployment of `MechMarketplace`, `BalanceTracker`s, and factories across Polygon, Optimism, Arbitrum, Ethereum, Gnosis, and Celo ([#131](https://github.com/valory-xyz/autonolas-marketplace/pull/131), [#137](https://github.com/valory-xyz/autonolas-marketplace/pull/137), [#142](https://github.com/valory-xyz/autonolas-marketplace/pull/142), [#146](https://github.com/valory-xyz/autonolas-marketplace/pull/146), [#147](https://github.com/valory-xyz/autonolas-marketplace/pull/147))
+- Ownership of `KarmaProxy` and `MechMarketplaceProxy` transferred to the DAO executor (timelock on mainnet, bridgeMediator on L2s) on all 7 chains
+- Internal audit 7 and `docs/Vulnerabilities_marketplace.md` ([#151](https://github.com/valory-xyz/autonolas-marketplace/pull/151))
+- `audit_contracts_setup.js` enhancements: `SubscriptionProvider` ownership coverage, Celo `BalanceTrackerFixedPriceNativeCelo` handling, public-RPC fallback ([#152](https://github.com/valory-xyz/autonolas-marketplace/pull/152))
+- CI: aggregate "All checks passed" gate job
+- Added `CONTRIBUTING.md`; license refresh
 
 ## [0.4.1] - 2024-03-14
 

--- a/docs/Vulnerabilities_marketplace.md
+++ b/docs/Vulnerabilities_marketplace.md
@@ -21,6 +21,7 @@
 | 13 | Karma `int256` theoretical overflow | Karma | Informative |
 | 14 | `trackerBalance` not decremented on withdrawal | BalanceTrackerNvmSubscriptionNative | Informative |
 | 15 | `SubscriptionProvider.fulfill()` permissionless | SubscriptionProvider | Informative |
+| 16 | `BalanceTrackerNvmSubscriptionNative.depositFor()` allows direct deposits | BalanceTrackerNvmSubscriptionNative | Low |
 
 The present document aims to point out some vulnerabilities in the autonolas-marketplace
 contracts.
@@ -312,3 +313,34 @@ their own access control and state machine checks internally. A permissionless c
 not meet the NVM preconditions will simply revert.
 
 No change is recommended. The NVM framework's internal access control is sufficient.
+
+### 16. `BalanceTrackerNvmSubscriptionNative.depositFor()` allows direct deposits
+**Severity**: Low
+
+`BalanceTrackerNvmSubscriptionNative` inherits from `BalanceTrackerFixedPriceNative`, which exposes
+a payable `depositFor(address account)` that credits the account's balance:
+```solidity
+function depositFor(address account) external payable virtual {
+    mapRequesterBalances[account] += msg.value;
+    emit Deposit(account, address(0), msg.value);
+}
+```
+Because the subscription variant did not override this function, anyone could send native funds
+through `depositFor()` and inflate `mapRequesterBalances`, bypassing the NFT subscription model
+(which is the only intended path for crediting balances on this contract). The companion
+`_getOrRestrictNativeValue()` already rejects `msg.value > 0` on a request, so the only remaining
+direct-funding path was `depositFor()`.
+
+The fix overrides `depositFor()` to unconditionally revert:
+```solidity
+function depositFor(address) external payable virtual override {
+    revert NoDepositAllowed(msg.value);
+}
+```
+This aligns `BalanceTrackerNvmSubscriptionNative` with `BalanceTrackerNvmSubscriptionToken`, which
+already reverts both `deposit()` and `depositFor()` on its token variant.
+
+**Deployment status:** the contract source has been updated, but the on-chain instances on
+Gnosis (`0x7D686bD1fD3CFF6E45a40165154D61043af7D67c`) and Base
+(`0x3d79737f05966c5925a04d1b04110006F5a072bE`) still run the pre-fix bytecode. They need to be
+redeployed before this vulnerability is closed on-chain.


### PR DESCRIPTION
> Replaces #153 (auto-closed when the branch was renamed from `v1.4.2` to `v0.4.2`). Same commit, same content.

## Summary

Two doc-only updates ahead of the upcoming **v0.4.2** tag:

### 1. New vulnerability entry — `BalanceTrackerNvmSubscriptionNative.depositFor()` allows direct deposits

Adds item **#16** (Severity: Low) to `docs/Vulnerabilities_marketplace.md`.

`BalanceTrackerNvmSubscriptionNative` inherits from `BalanceTrackerFixedPriceNative`, which exposes a payable `depositFor(address)` that credits `mapRequesterBalances[account] += msg.value`. The subscription variant did **not** previously override this function, so anyone could send native funds through `depositFor()` and inflate balance bookkeeping, bypassing the NFT subscription model (the only intended crediting path on this contract).

The fix (`979d480`, originally PR #129) overrides `depositFor()` to revert unconditionally with `NoDepositAllowed`. This brings the native subscription variant in line with the token subscription variant, which already reverts both `deposit()` and `depositFor()`.

**Deployment status (verified via `cast call` against deployed bytecode):**
- gnosis (chain 100) `0x7D686bD1fD3CFF6E45a40165154D61043af7D67c` — **still pre-fix**, `depositFor(0x…01)` does not revert.
- base (chain 8453) `0x3d79737f05966c5925a04d1b04110006F5a072bE` — **still pre-fix**, same behavior.

Both instances need to be redeployed (or migrated) before the vulnerability is closed on-chain. The entry's closing line in the doc notes that the contract code is updated but not yet deployed.

### 2. Changelog — project `v0.4.2`

Adds `[0.4.2] - 2026-05-25` to `CHANGELOG.md`, covering the 86 commits since `v0.4.1`:
- New USDC fixed-price contracts (`MechFactoryFixedPriceTokenUSDC`, `MechFixedPriceTokenUSDC`)
- New Celo `BalanceTrackerFixedPriceNativeCelo` variant
- The `depositFor()` revert fix on `BalanceTrackerNvmSubscriptionNative`
- Multi-chain deployment (Polygon, Optimism, Arbitrum, Ethereum, Gnosis, Celo)
- DAO ownership transfer of `KarmaProxy` / `MechMarketplaceProxy` on all 7 chains
- Internal audit 7 + `Vulnerabilities_marketplace.md`
- `audit_contracts_setup.js` enhancements (SubscriptionProvider, Celo variant, public-RPC fallback)
- CI aggregate gate, `CONTRIBUTING.md`, license refresh

## Test

- `eslint . --ext .js,.jsx,.ts,.tsx` — passes (0 errors, 6 pre-existing warnings unrelated to this change).
- Docs-only change; nothing else to verify locally.