### PR TITLE
chore(celo): point olasAddress to native OLAS-CELO

### DIFF
--- a/scripts/deployment/globals_celo_mainnet.json
+++ b/scripts/deployment/globals_celo_mainnet.json
@@ -24,7 +24,7 @@
   "agentRegistryAddress": "0xE49CB081e8d96920C38aA7AB90cb0294ab4Bc8EA",
   "agentFactoryAddress": "0x87c511c8aE3fAF0063b3F3CF9C6ab96c4AA5C60c",
   "agentFactorySubscriptionAddress": "0x88DE734655184a09B70700aE4F72364d1ad23728",
-  "olasAddress": "0xD80533CA29fF6F033a0b55732Ed792af9Fbb381E",
+  "olasAddress": "0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51",
   "bridgeMediatorAddress": "0xC14E191A64a7FB0e5790a8a0B9a58683dFFce04d",
   "serviceRegistryAddress": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
   "drainerAddress": "0x11949cBC85d8793B360029E26b18ae759708e28b",


### PR DESCRIPTION
## Summary
- Update `scripts/deployment/globals_celo_mainnet.json` `olasAddress` from the Wormhole-bridged whOLAS (`0xD80533CA29fF6F033a0b55732Ed792af9Fbb381E`) to native OLAS-CELO (`0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51`).
- Aligns the marketplace's Celo OLAS pointer with the canonical OLAS already used on-chain by `BuyBackBurner.olas()` (verified) and `Bridge2Burner` on Celo, post-`LPSwapCelo` migration.
- Sole purpose: the next `BalanceTrackerFixedPriceTokenOLAS` deployment on Celo (via `deploy_08a_balance_tracker_fixed_price_token_olas.sh celo_mainnet`) will read this field and pass native OLAS-CELO as its `_token` immutable, closing the whOLAS→treasury misroute on Celo's OLAS-fee path.

## Scope
- Single field change in one committed globals file. No code, no contracts, no other globals.
- Verified no other committed file in the marketplace repo references the whOLAS address. The tokenomics references (`LPSwapCelo.sol`, staking globals) are intentional and out of scope.

## Test plan
- [ ] CI: lint + tests + gitleaks all green (gitleaks already verified clean locally).
- [ ] Post-merge: run `./scripts/deployment/deploy_08a_balance_tracker_fixed_price_token_olas.sh celo_mainnet` to deploy the new tracker.
- [ ] Post-deploy: governance vote to call `MechMarketplace.setPaymentTypeBalanceTrackers([0x3679d66ef546e66ce9057c4a052f317b135bc8e8c509638f7966edfd4fcf45e9], [<newTracker>])` (owner is OptimismMessenger `0xC14E191A64a7FB0e5790a8a0B9a58683dFFce04d`).
- [ ] Post-deploy: run `node scripts/audit_chains/audit_contracts_setup.js`.