### PR TITLE
chore(celo): point drainerAddress to redeployed native-OLAS BBB proxy

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -229,4 +229,5 @@ ad71fd4b9892a4e7b0f76b294c4fde6b18663b34:scripts/deployment/globals_eth_mainnet.
 ad71fd4b9892a4e7b0f76b294c4fde6b18663b34:scripts/deployment/globals_eth_mainnet.json:generic-api-key:28
 ad71fd4b9892a4e7b0f76b294c4fde6b18663b34:scripts/deployment/globals_eth_mainnet.json:generic-api-key:29
 ba896fdce4ba4df320ef592c3acc1366f5cf9442:scripts/deployment/globals_arbitrum_mainnet.json:generic-api-key:31
+e08b32e1e639b2f183894aaf92a7062e87c360b8:scripts/deployment/globals_celo_mainnet.json:generic-api-key:44
   

--- a/scripts/deployment/globals_celo_mainnet.json
+++ b/scripts/deployment/globals_celo_mainnet.json
@@ -27,7 +27,7 @@
   "olasAddress": "0xD80533CA29fF6F033a0b55732Ed792af9Fbb381E",
   "bridgeMediatorAddress": "0xC14E191A64a7FB0e5790a8a0B9a58683dFFce04d",
   "serviceRegistryAddress": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
-  "drainerAddress": "0x11949cBC85d8793B360029E26b18ae759708e28b",
+  "drainerAddress": "0x847bBE8b474e0820215f818858e23F5f5591855A",
   "wrappedNativeTokenAddress": "0x471EcE3750Da237f93B8E339c536989b8978a438",
   "usdcAddress": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
   "fee": "0",


### PR DESCRIPTION
## Summary
- Update `scripts/deployment/globals_celo_mainnet.json` `drainerAddress` from the old Celo BBB proxy (`0x11949cBC85d8793B360029E26b18ae759708e28b`) to the freshly redeployed one (`0x847bBE8b474e0820215f818858e23F5f5591855A`).
- The old BBB proxy's `olas` storage slot was permanently stuck on whOLAS (`0xaCFf…dc51`) — set at v0.2.0 init, and `initialize()` is one-shot; the audited v0.3.0 impl cannot be modified to add a setter. So the BBB was redeployed fresh with `olas` correctly pinned to native OLAS-CELO.
- This is the prerequisite for redeploying the three Celo balance trackers (their `drainer` is constructor-immutable), so it should merge before that deploy runs.

## On-chain verification of the new BBB proxy `0x847b…855A`
- `VERSION() = "0.3.0"`
- `olas() = 0xD80533CA29fF6F033a0b55732Ed792af9Fbb381E` (native OLAS-CELO, per `LPSwapCelo.OLAS`)
- `owner() = treasury() = 0xC14E191A64a7FB0e5790a8a0B9a58683dFFce04d` (OptimismMessenger — audit C-01 closed on Celo)
- `router() = 0xE3D8bd6Aed4F159bc8000a9cD47CffDb95F96121` (Ubeswap V2); `swapRouter()` (V3) = 0 (disabled)
- `bridge2Burner.olas() = 0xD8053…381E` (native OLAS), `l2TokenRelayer = 0x4200…0010` (OP-stack L2 bridge)

## Scope
- Single field in one globals file. `olasAddress` already correct (native OLAS) and untouched.

## Test plan
- [ ] CI green (gitleaks verified clean locally; JSON-only change, no lint/compile/test surface).
- [ ] Post-merge: redeploy the three Celo trackers via `deploy_06_celo_balance_tracker_fixed_price_native.sh`, `deploy_08a_balance_tracker_fixed_price_token_olas.sh`, `deploy_08b_balance_tracker_fixed_price_token_usdc.sh` (celo_mainnet).
- [ ] Governance vote: `MechMarketplace.setPaymentTypeBalanceTrackers(...)` to wire the new trackers (owner = OptimismMessenger).
- [ ] Pending BBB-side governance: `setV2Oracles([WCELO],[oracle])` + `setMaxSlippages` — `mapV2Oracles[WCELO]` is currently 0 on the new proxy.