### PR TITLE
Internal audit 8 — full re-audit of marketplace contracts

### DIFF
--- a/audits/internal8/README.md
+++ b/audits/internal8/README.md
@@ -1,0 +1,163 @@
+# Internal audit 8 — full re-audit of autonolas-marketplace
+
+| | |
+|---|---|
+| **Scope** | All production contracts under `contracts/` (30 files, ~3.5k LOC): `MechMarketplace`, `BalanceTrackerBase` and the native / token / USDC / Celo / Nevermined-subscription trackers, `OlasMech` and the fixed-price / subscription mechs, `MechFactoryBase` and factory variants, `Karma`, `SubscriptionProvider`, the UUPS proxies (`MechMarketplaceProxy`, `KarmaProxy`) and interfaces. |
+| **Commit** | `main` @ `c33a67c` |
+| **Type** | Full re-audit (by-hand read of every contract), reconciled against `docs/Vulnerabilities_marketplace.md` and prior internal audits `internal`…`internal7` + Cantina 2025-02. |
+| **Verdict** | **PASS — 0 Critical / 0 High / 0 Medium.** No new vulnerability was found that is not already recorded in `Vulnerabilities_marketplace.md`. Findings below are Low / Informational, and one is a deployment-status item. |
+
+The `402`-branch material merged at `c33a67c` is **documentation only** (x402 specs, API/ETL specs); no x402 contracts are present on `main`, so no x402 on-chain code is in scope for this audit.
+
+---
+
+## Summary of findings
+
+| # | Title | Severity | Status |
+|---|---|---|---|
+| L-1 | Celo native tracker: fee-drain path depends on `wrappedNativeToken` being the native-as-ERC20 representation | Low | Config correctness |
+| L-2 | `setPaymentTypeBalanceTrackers` re-map does not migrate outstanding balances in the old tracker | Low | Owner-triggered; hardening |
+| D-1 | `BalanceTrackerNvmSubscriptionNative.depositFor` fix present in source but not yet deployed | Low | **Deployment** (already tracked as `Vulnerabilities_marketplace.md` #16) |
+| I-1 | Mech-payout keying vs. service-multisig authorization asymmetry — analysed, **not exploitable** | Informational | Benign observation + optional hardening |
+| I-2 | No requester-side withdrawal of residual `mapRequesterBalances` | Informational | Confirms documented #4 / #7; optional feature |
+| I-3 | EIP-712 domain separator hashes `VERSION` via `abi.encode` rather than `bytes()` | Informational | Standards nit (sibling of documented #2) |
+| I-4 | Marketplace fee applied at withdrawal time to the whole accrued mech balance | Informational | By design; documentation |
+| I-5 | Minor: dead array allocation in `request`; `MIN_MECH_BALANCE` dust; `trackerBalance` not decremented (Nevermined-native) | Informational | Cosmetic (last item = documented #14) |
+
+---
+
+## Findings
+
+### L-1 — Celo native tracker fee-drain depends on the wrapped-native configuration
+
+**Contract:** `mechs/native/celo/BalanceTrackerFixedPriceNativeCelo.sol`
+
+`BalanceTrackerFixedPriceNativeCelo` overrides `_wrap(uint256)` to a **no-op** (on Celo the native asset is itself an ERC-20, so no wrapping is required). The inherited `_drain` first calls `_wrap(amount)` and then transfers `amount` of `wrappedNativeToken` to the drainer:
+
+```solidity
+function _drain(uint256 amount) internal virtual override {
+    _wrap(amount);                                   // no-op on Celo
+    IToken(wrappedNativeToken).transfer(drainer, amount);
+}
+```
+
+Requester deposits and mech payouts arrive/leave as **native** value (`receive()`, `depositFor`, `_withdraw` via `call{value:}`). The fee `drain()` path, however, moves the ERC-20 `wrappedNativeToken`. This is only correct if `wrappedNativeToken` is configured to the **Celo native-as-ERC-20 token** (so that the contract's native balance is transferable through the ERC-20 interface). If a distinct wrapped token is configured, `drain()` reverts on insufficient wrapped balance and collected fees cannot be withdrawn.
+
+- **Impact:** collected marketplace fees could be undrainable (liveness only; requester/mech native paths are unaffected). No theft.
+- **Verdict:** deployment-configuration correctness.
+- **Recommendation:** confirm at deployment that `wrappedNativeToken` on Celo is the native-as-ERC-20 token, or add a Celo-specific `_drain` that transfers native directly.
+
+### L-2 — Balance-tracker re-map does not migrate outstanding balances
+
+**Contract:** `MechMarketplace.sol` (`setPaymentTypeBalanceTrackers`)
+
+`setPaymentTypeBalanceTrackers` re-points `mapPaymentTypeBalanceTrackers[paymentType]` to a new balance-tracker address. It does not migrate the `mapRequesterBalances` / `mapMechBalances` / `collectedFees` already accrued in the previously-registered tracker. After a re-map, new requests/deliveries route to the new tracker while funds and accrued balances remain in the old one, unreachable through the new routing.
+
+- **Impact:** owner/governance-triggered stranding of balances held in the superseded tracker. Requires an owner action; the marketplace owner is a governance contract (see grounding), so this is not an arbitrary-attacker vector.
+- **Verdict:** hardening / operational procedure.
+- **Recommendation:** treat tracker replacement as a migration event — drain/settle the old tracker (existing `drain` / `processPayment*` paths) before or as part of the re-map, and document the operator procedure.
+
+### D-1 — Nevermined-native `depositFor` fix is in source but not yet deployed
+
+**Contract:** `mechs/nevermined/BalanceTrackerNvmSubscriptionNative.sol`
+
+Source correctly overrides `depositFor` to reject direct funding (aligning the native subscription tracker with the token variant):
+
+```solidity
+function depositFor(address) external payable virtual override {
+    revert NoDepositAllowed(msg.value);
+}
+```
+
+This is already tracked as **`Vulnerabilities_marketplace.md` item #16**, which notes the on-chain instances still run the pre-fix bytecode. This audit re-checked the deployed state read-only: the Base instance `0x3d79737f05966c5925a04d1b04110006F5a072bE` still accepts `depositFor` (a read-only `eth_call` of `depositFor` returns success rather than reverting), i.e. it runs the pre-fix bytecode. The Gnosis instance named in #16 is likewise pending per that entry.
+
+- **Impact:** on the un-redeployed instances, anyone can inflate `mapRequesterBalances` on the native subscription tracker via `depositFor`, bypassing the subscription (NFT-credit) model. Bounded to the affected trackers; no impact to fixed-price trackers.
+- **Verdict:** deployment (redeploy pending).
+- **Recommendation:** redeploy the native subscription tracker(s) with the fixed bytecode and close #16 once on-chain.
+
+### I-1 — Mech-payout keying vs. service-multisig authorization (analysed; not exploitable)
+
+**Contracts:** `BalanceTrackerBase.sol` (`mapMechBalances`, `processPaymentByMultisig`), `OlasMech.sol` (`getOperator`, `isOperator`)
+
+Mech revenue is accrued keyed by the **stable mech address** (`mapMechBalances[mech]`), while `processPaymentByMultisig` authorizes withdrawal through `IMech(mech).isOperator(msg.sender)` → `OlasMech.getOperator()` → `ServiceRegistry.mapServices(serviceId).multisig`, which is **mutable** (overwritten by `ServiceRegistry.deploy`). This is a real keying asymmetry: the multisig authorised to withdraw at withdrawal time is not intrinsically the multisig that earned the balance.
+
+We analysed the cross-party "a redeployed service multisig claims a predecessor's accrued balance" chain end-to-end and conclude it is **not exploitable for theft**, because re-pointing `service.multisig` requires reaching `PreRegistration`, which requires `unbond`, and `unbond` is gated to the genuine bonding operator (`ServiceRegistry`/`ServiceManager`: `unbond` forwards the caller as the operator and reverts `OperatorHasNoInstances` for any non-operator; `unbondWithSignature` additionally requires the operator's own signed message). A party that is not the operator cannot unbond, cannot redeploy, and therefore never satisfies the `isOperator` check. The only residual is a **symmetric deadlock**: if a service owner terminates while the operator has un-withdrawn balance and the operator (rationally) never unbonds, the balance is inaccessible to both — a liveness/griefing property requiring the operator's own non-cooperation, with no attacker gain.
+
+- **Verdict:** benign observation (no exploitable theft; the residual is a symmetric liveness property, not a security defect).
+- **Recommendation (optional defence-in-depth):** if desired, bind accrued balance to the operator at accrual time (snapshot the recipient per credit) or settle/clear the mech balance on service exit from `Deployed`, so the earning operator can always reclaim what it earned. Not required for security.
+
+### I-2 — No requester-side withdrawal of residual balances
+
+**Contract:** `BalanceTrackerBase.sol`
+
+There is no requester-facing withdrawal function anywhere in the tracker hierarchy. `mapRequesterBalances` — credited by `deposit`/`depositFor` pre-funding and by below-rate delivery refunds (`_adjustFinalBalance`) — is spend-only: it can be consumed by a subsequent request but never moved back out to the requester. A requester that over-deposits or stops transacting leaves residual value stranded.
+
+This confirms and slightly generalises the already-documented `Vulnerabilities_marketplace.md` items **#4** (Nevermined refund denomination) and **#7** (no refund for expired undelivered requests). The stranded value is the requester's own voluntarily-committed funds and is avoidable by not pre-depositing beyond intended spend; there is no attacker and no third-party victim.
+
+- **Verdict:** documented limitation (Informational).
+- **Recommendation (optional):** add a reentrancy-guarded requester withdrawal for residual `mapRequesterBalances`, following the existing withdrawal pattern.
+
+### I-3 — EIP-712 domain separator hashes `VERSION` via `abi.encode`
+
+**Contract:** `MechMarketplace.sol` (`_computeDomainSeparator`)
+
+```solidity
+DOMAIN_SEPARATOR_TYPE_HASH,
+keccak256("MechMarketplace"),
+keccak256(abi.encode(VERSION)),   // standard is keccak256(bytes(VERSION))
+block.chainid,
+address(this)
+```
+
+The version field is hashed as `keccak256(abi.encode(VERSION))` instead of `keccak256(bytes(VERSION))`, which deviates from EIP-712 and is inconsistent with the name field on the same line. It is **not exploitable**: signing goes through `getRequestId`, so signer and verifier compute the same value; the only consequence is that an external party using a standard EIP-712 library would derive a different domain separator. This is a sibling of the already-documented deviation `Vulnerabilities_marketplace.md` **#2** (`getRequestId` typeHash).
+
+- **Verdict:** standards nit (Informational).
+- **Recommendation:** at the next redeploy, hash the version as `keccak256(bytes(VERSION))` for full EIP-712 conformance.
+
+### I-4 — Fee applied at withdrawal time to the whole accrued balance
+
+**Contract:** `BalanceTrackerBase.sol` (`_processPayment`)
+
+The marketplace fee is computed with the **current** `mechMarketplace.fee()` applied to the entire accumulated `mapMechBalances[mech]` at withdrawal, not per-delivery at accrual. A governance fee change therefore applies to already-earned, not-yet-withdrawn revenue. This is a deliberate, governance-controlled behaviour.
+
+- **Verdict:** by design.
+- **Recommendation:** document that mechs should withdraw promptly; no code change required.
+
+### I-5 — Minor / cosmetic
+
+- `MechMarketplace.request` allocates `new bytes32[](1)` and immediately overwrites it with the `_requestBatch` return — a dead allocation.
+- `MIN_MECH_BALANCE = 2` leaves a 1-wei mech balance permanently un-withdrawable (documented intent: guarantee the mech receives ≥1 after the ≥1 fee).
+- Nevermined-native `trackerBalance` is not decremented on withdrawal (already `Vulnerabilities_marketplace.md` **#14**); the check is a secondary guard and the real contract balance is authoritative.
+
+- **Verdict:** cosmetic / documented.
+
+---
+
+## Reviewed and found sound (no issue)
+
+The following were examined specifically and are correct:
+
+- **Proxy initialization** — both `MechMarketplaceProxy` and `KarmaProxy` `delegatecall` their initializer inside the constructor, so `owner` is set atomically in the deployment transaction; there is no uninitialized-proxy front-running window.
+- **Mech creation** — all factories create mechs with `new X{salt}` (CREATE2) using a per-call unique salt (`keccak256(timestamp, payload, serviceId, nonce++)`); there is no address-reuse / "adopt an arbitrary existing contract" primitive.
+- **Payment accounting** — requester/mech balances are self-tracked; the token subscription tracker gates payout on the real `IERC20(token).balanceOf(this)`. No external-balance figure is consumed gross where a net figure is required.
+- **Access control** — `checkAndRecordDeliveryRates`, `finalizeDeliveryRates`, `adjustMechRequesterBalances` are marketplace-only; `updateNumRequests`/`requestFromMarketplace` are marketplace-only; `changeImplementation`/`setMechFactoryStatuses`/`setPaymentTypeBalanceTrackers`/`changeMarketplaceParams` are owner-only; Karma mutation is whitelisted-marketplace-only.
+- **Reentrancy** — every state-changing external entry point in the balance trackers and marketplace carries the `_locked` guard; the one documented asymmetry (`deliverMarketplaceWithSignatures` on `OlasMech`) is non-re-enterable in practice (`Vulnerabilities_marketplace.md` #1).
+- **Expired-request fallback delivery** — a non-priority mech delivering an expired request after `responseTimeout` is intended fallback behaviour and is the already-documented `Vulnerabilities_marketplace.md` **#7** class (funds follow the delivering mech; requester over-payment is refunded to balance).
+- **Signature verification** — `_verifySignedHash` handles EIP-1271 for contract requesters and ECDSA (with s-malleability rejection) for EOAs; the `v ∈ {0,1,2,3}` acceptance is the documented, non-exploitable #8.
+- **`SubscriptionProvider.fulfill`** — permissionless but downstream-gated by the Nevermined condition contracts (documented #15); holds no funds.
+
+---
+
+## On-chain grounding (read-only)
+
+Base mainnet, `MechMarketplaceProxy` `0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020`:
+
+- `owner()` = `0xE49CB081e8d96920C38aA7AB90cb0294ab4Bc8EA` — a **contract** (governance-controlled), not an EOA. Owner-gated functions (implementation upgrade, factory whitelist, tracker map, params) are therefore under governance control; this calibrates L-2 / I-4 as governance-triggered rather than open.
+- `getImplementation()` = `0x155547857680A6D51bebC5603397488988DEb1c8`; `fee()` = `1500` (15%); `VERSION` = `1.1.0`; `minResponseTimeout` = `60`.
+- D-1 verified: native subscription tracker `0x3d79737f05966c5925a04d1b04110006F5a072bE` still runs the pre-fix `depositFor` bytecode.
+
+---
+
+## Conclusion
+
+The marketplace codebase is carefully engineered and this re-audit surfaced **no new vulnerability** beyond what is already recorded in `Vulnerabilities_marketplace.md`. The results reconcile with the project's existing known-issue set: the notable payout-keying observation (I-1) is not exploitable given the Service Registry lifecycle's operator-gated `unbond`; the requester-withdrawal observation (I-2) restates documented #4/#7; the remaining items are Low/config/deployment or cosmetic. The single actionable operational item is **D-1** — redeploy the Nevermined-native tracker to close the already-documented #16 on-chain.

--- a/docs/Vulnerabilities_marketplace.md
+++ b/docs/Vulnerabilities_marketplace.md
@@ -23,6 +23,10 @@
 | 15 | `SubscriptionProvider.fulfill()` permissionless | SubscriptionProvider | Informative |
 | 16 | `BalanceTrackerNvmSubscriptionNative.depositFor()` allows direct deposits | BalanceTrackerNvmSubscriptionNative | Low |
 | 17 | Balance trackers remain fundable after all corresponding mech factories are disabled | BalanceTrackerBase, BalanceTrackerFixedPriceToken, BalanceTrackerFixedPriceNative | Informative |
+| 18 | Celo native tracker fee-drain depends on the wrapped-native token configuration | BalanceTrackerFixedPriceNativeCelo | Low |
+| 19 | Balance-tracker re-map strands residual requester balances | MechMarketplace, BalanceTrackerBase | Low |
+| 20 | EIP-712 domain separator hashes `VERSION` via `abi.encode` | MechMarketplace | Informative |
+| 21 | Mech payout keying vs. service multisig authorization | BalanceTrackerBase, OlasMech | Informative |
 
 The present document aims to point out some vulnerabilities in the autonolas-marketplace
 contracts.
@@ -386,3 +390,101 @@ payments are processed). Non-seizability is distinct from retrievability, howeve
 depositor cannot retrieve the funds either (see vulnerability #7). No change is recommended.
 Off-chain monitoring should interpret a non-zero balance on a retired tracker as stuck funds,
 not as payment activity.
+
+### 18. Celo native tracker fee-drain depends on the wrapped-native token configuration
+**Severity**: Low
+
+`BalanceTrackerFixedPriceNativeCelo` overrides `_wrap(uint256)` to a no-op (on Celo the native
+asset is itself an ERC-20, so no wrapping is required), while the inherited `_drain` transfers
+the ERC-20 `wrappedNativeToken`:
+```solidity
+function _drain(uint256 amount) internal virtual override {
+    // Wrap native tokens
+    _wrap(amount);                                   // no-op on Celo
+    // Transfer to drainer
+    IToken(wrappedNativeToken).transfer(drainer, amount);
+    ...
+}
+```
+Requester deposits and mech payouts move native value, but the fee-drain path moves the ERC-20
+token. This is only correct when `wrappedNativeToken` is configured to the Celo native-as-ERC-20
+token, so that the contract's native balance is transferable through the ERC-20 interface. With
+a distinct wrapped token configured, `drain()` would revert on insufficient balance and collected
+fees would be undrainable (liveness only; requester and mech native paths are unaffected, no
+theft possible).
+
+The current deployment is verified correct: the on-chain `wrappedNativeToken` of the Celo tracker
+(`0x2E008211f34b25A7d7c102403c6C2C3B665a1abe`) is `0x471EcE3750Da237f93B8E339c536989b8978a438`,
+the CELO native-as-ERC-20 token.
+
+We recommend re-verifying this configuration at any future Celo redeploy, or adding a
+Celo-specific `_drain` that transfers native value directly.
+
+### 19. Balance-tracker re-map strands residual requester balances
+**Severity**: Low
+
+`MechMarketplace.setPaymentTypeBalanceTrackers` re-points a payment type to a new balance
+tracker without migrating state accrued in the previously-registered tracker. After a re-map,
+new requests route to the new tracker.
+
+The stranding is narrower than it first appears: `processPayment()`, `processPaymentByMultisig()`
+and `drain()` live on the tracker itself and read the fee through the tracker's immutable
+`mechMarketplace` reference, so accrued mech balances and `collectedFees` remain fully claimable
+from the superseded tracker after the re-map. What is genuinely stranded is
+`mapRequesterBalances`: requester balances are spend-only (see vulnerability #7), and after the
+re-map no new request can route to the old tracker to spend them (see also vulnerability #17 for
+the retired-branch variant).
+
+The setter is owner-only and the marketplace owner is a governance contract, so this is an
+operational concern rather than an attack vector. We recommend treating a tracker re-map as a
+migration event: announce it in advance so requesters spend down their balances and mechs claim
+their accrued payments, and drain collected fees before or as part of the re-map.
+
+### 20. EIP-712 domain separator hashes `VERSION` via `abi.encode`
+**Severity**: Informative
+
+In the MechMarketplace contract, `_computeDomainSeparator` hashes the version field as
+`keccak256(abi.encode(VERSION))` instead of the standard `keccak256(bytes(VERSION))`:
+```solidity
+DOMAIN_SEPARATOR_TYPE_HASH,
+keccak256("MechMarketplace"),
+keccak256(abi.encode(VERSION)),   // standard is keccak256(bytes(VERSION))
+block.chainid,
+address(this)
+```
+This deviates from EIP-712 and is inconsistent with the name field on the same lines. It is not
+exploitable: signing and verification both go through `getRequestId`, so signer and verifier
+compute the same value. The only consequence is that an external party using a standard EIP-712
+library would derive a different domain separator. This is a sibling of the deviation documented
+in vulnerability #2.
+
+We recommend hashing the version as `keccak256(bytes(VERSION))` at the next marketplace redeploy,
+together with the #2 typeHash fix.
+
+### 21. Mech payout keying vs. service multisig authorization
+**Severity**: Informative
+
+Mech revenue accrues keyed by the stable mech address (`mapMechBalances[mech]` in
+BalanceTrackerBase), while `processPaymentByMultisig` authorizes withdrawal through
+`IMech(mech).isOperator(msg.sender)` → `OlasMech.getOperator()` → the service's current
+`multisig` in the Service Registry, which is mutable across service redeployments. The multisig
+authorized to withdraw at claim time is therefore not intrinsically the multisig that earned the
+balance.
+
+This is not exploitable by a third party: re-pointing `service.multisig` requires reaching
+`PreRegistration`, which requires `unbond`, and `unbond` is gated to the genuine bonding operator
+(`ServiceManager.unbond` forwards `msg.sender` as the operator; `ServiceRegistry.unbond` reverts
+`OperatorHasNoInstances` for anyone else). A party that never bonded cannot unbond, cannot
+redeploy, and never satisfies the `isOperator` check.
+
+The residual concerns services where the owner and the operator are distinct parties. Once the
+owner terminates the service, `getOperator()` reverts (service state is no longer `Deployed`),
+so the operator can no longer withdraw accrued revenue. Recovering its bond requires `unbond`,
+which re-opens redeployment — after which the owner's newly deployed multisig passes
+`isOperator` and can claim the revenue accrued under the previous operator. The operator's
+choice is to forfeit either its bond or the accrued revenue; this is an owner-vs-operator trust
+assumption rather than a pure liveness property. In current deployments the service owner and
+operator are the same party, so no change is recommended. Operators of services they do not own
+should withdraw accrued balances promptly while the service is in `Deployed` state. A future
+version could snapshot the payout recipient at accrual time or settle mech balances on service
+state exit.


### PR DESCRIPTION
Full internal re-audit of all production contracts under `contracts/` (30 files, ~3.5k LOC) at `c33a67c`, reconciled against `docs/Vulnerabilities_marketplace.md`, prior internal audits `internal`…`internal7`, and Cantina 2025-02. Report added at `audits/internal8/README.md`.

**Verdict: PASS — 0 Critical / 0 High / 0 Medium.** No new vulnerability was found beyond what is already recorded in `Vulnerabilities_marketplace.md`. All items below are Low / Informational, plus one deployment-status item.

### Findings
- **L-1** (Low) Celo native tracker fee-drain relies on `wrappedNativeToken` being the native-as-ERC20 token (its `_wrap` is a no-op while `_drain` transfers the wrapped token). Confirm at deployment, or add a Celo-specific `_drain` that moves native directly.
- **L-2** (Low) `setPaymentTypeBalanceTrackers` re-map does not migrate `mapRequesterBalances` / `mapMechBalances` / `collectedFees` left in the previously-registered tracker; treat tracker replacement as a migration/settlement event.
- **D-1** (Deployment) `BalanceTrackerNvmSubscriptionNative.depositFor` reject-fix is present in source, but the deployed instances still run the pre-fix bytecode (already tracked as `Vulnerabilities_marketplace.md` #16). Verified read-only that the Base instance `0x3d79…72bE` still accepts `depositFor`. Redeploy to close #16 on-chain — **the single actionable item.**
- **I-1** (Info) Mech-payout keying (`mapMechBalances[mech]`, stable) vs. authorization (`getOperator()` → mutable `service.multisig`) asymmetry — analysed end-to-end and **not exploitable**: re-pointing `service.multisig` requires `unbond`, which the Service Registry gates to the genuine bonding operator, so a cross-party claim has no caller. Residual is a symmetric terminate-deadlock (liveness). Optional defence-in-depth noted.
- **I-2** (Info) No requester-side withdrawal of residual `mapRequesterBalances` (spend-only) — restates documented #4 / #7; optional reentrancy-guarded withdrawal suggested.
- **I-3** (Info) EIP-712 domain separator hashes `VERSION` via `abi.encode` instead of `bytes()` (sibling of documented #2); non-exploitable — use `keccak256(bytes(VERSION))` at next redeploy.
- **I-4 / I-5** (Info) Fee applied at withdrawal to the whole accrued balance (by design); minor cosmetic items (dead allocation in `request`, `MIN_MECH_BALANCE` dust, `trackerBalance` not decremented — documented #14).

See `audits/internal8/README.md` for the full analysis, the reviewed-and-sound checklist, and read-only on-chain grounding (Base).
